### PR TITLE
Try to prevent OSGi from bundling all of scala-library.jar.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Keys.{`package` => packageTask }
 
 // plugin logic of build based on https://github.com/retronym/boxer
 
-lazy val commonSettings = scalaModuleSettings ++ Seq(
+lazy val commonSettings = Seq(
   repoName                   := "scala-continuations",
   organization               := "org.scala-lang.plugins",
   version                    := "1.0.0-SNAPSHOT",
@@ -16,12 +16,12 @@ lazy val root = project.in( file(".") ).settings( publishArtifact := false ).agg
 lazy val plugin = project settings (
   name                := "scala-continuations-plugin",
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
-) settings (commonSettings : _*)
+) settings(scalacPluginSettings: _*) settings (commonSettings : _*)
 
 val pluginJar = packageTask in (plugin, Compile)
 
 // TODO: the library project's test are really plugin tests, but we first need that jar
-lazy val library = project settings (
+lazy val library = project.settings(scalaModuleSettings: _*).settings(commonSettings: _*).settings(
   name                 := "scala-continuations-library",
   scalacOptions       ++= Seq(
     // add the plugin to the compiler
@@ -38,5 +38,6 @@ lazy val library = project settings (
   testOptions          += Tests.Argument(
     TestFrameworks.JUnit,
     s"-Dscala-continuations-plugin.jar=${pluginJar.value.getAbsolutePath}"
-  )
-) settings (commonSettings : _*)
+  ),
+  OsgiKeys.exportPackage := Seq(s"scala.util.continuations;version=${version.value}")
+)

--- a/project/ContinuationsBuild.scala
+++ b/project/ContinuationsBuild.scala
@@ -14,7 +14,8 @@ object Settings {
 
   val osgiVersion = version(_.replace('-', '.'))
 
-  lazy val scalaModuleSettings = SbtOsgi.osgiSettings ++ Seq(
+
+  lazy val scalacPluginSettings = Seq(
     repoName := name.value,
 
     scalaBinaryVersion := deriveBinaryVersion(scalaVersion.value, snapshotScalaBinaryVersion.value),
@@ -26,6 +27,7 @@ object Settings {
     // TODO: turn on for nightlies, but don't enable for PR validation... "-Xfatal-warnings"
     scalacOptions in compile ++= Seq("-optimize", "-feature", "-deprecation", "-unchecked", "-Xlint"),
 
+
     // Generate $name.properties to store our version as well as the scala version used to build
     resourceGenerators in Compile <+= Def.task {
       val props = new java.util.Properties
@@ -36,11 +38,6 @@ object Settings {
       IO.write(props, null, file)
       Seq(file)
     },
-
-    mappings in (Compile, packageBin) += {
-       (baseDirectory.value / s"${name.value}.properties") -> s"${name.value}.properties"
-    },
-
 
     // maven publishing
     publishTo := {
@@ -87,8 +84,10 @@ object Settings {
           <name>Typesafe, Inc.</name>
         </developer>
       </developers>
-    ),
+    )
+  )
 
+  lazy val scalaModuleSettings = SbtOsgi.osgiSettings ++ scalacPluginSettings ++ Seq(
     OsgiKeys.bundleSymbolicName := s"${organization.value}.${name.value}",
     OsgiKeys.bundleVersion := osgiVersion.value,
     OsgiKeys.exportPackage := Seq(s"*;version=${version.value}"),


### PR DESCRIPTION
- Move settings around so common settings are set first, before overrides.
- Remove osgi bundle settings from the scalac plugin.
- Remove the duplicate definition of the .properties file in mappings + resourceGenerators (thread issue)

Review by @adriaanm
