### PR TITLE
Fail fast in toolbox tests upon absent plugin JAR

### DIFF
--- a/library/src/test/scala/scala/tools/selectivecps/CompilerErrors.scala
+++ b/library/src/test/scala/scala/tools/selectivecps/CompilerErrors.scala
@@ -206,7 +206,12 @@ class CompilerErrors extends CompilerTesting {
 }
 
 class CompilerTesting {
-  def loadPlugin = s"-Xplugin:${sys.props("scala-continuations-plugin.jar")} -P:continuations:enable"
+  private def pluginJar: String = {
+    val f = sys.props("scala-continuations-plugin.jar")
+    assert(new java.io.File(f).exists, f)
+    f
+  }
+  def loadPlugin = s"-Xplugin:${pluginJar} -P:continuations:enable"
 
   // note: `code` should have a | margin
   def cpsErrorMessages(msg: String, code: String) =


### PR DESCRIPTION
To help us diagnose the likely cause of:

   https://github.com/retronym/community-builds/commit/964debeb52

Review by @adriaanm
