### PR TITLE
Clean up the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,24 @@
-import com.typesafe.tools.mima.plugin.{MimaPlugin, MimaKeys}
-import Keys.{`package` => packageTask }
-import com.typesafe.sbt.osgi.{OsgiKeys, SbtOsgi}
+import Keys.{ `package` => packageTask }
 
 // plugin logic of build based on https://github.com/retronym/boxer
 
 lazy val commonSettings = scalaModuleSettings ++ Seq(
-  repoName                   := "scala-continuations",
-  organization               := "org.scala-lang.plugins",
-  version                    := "1.0.3-SNAPSHOT",
-  scalaVersion               := crossScalaVersions.value.head,
-  crossScalaVersions         := {
-    val java = System.getProperty("java.version")
-    if (java.startsWith("1.6.") || java.startsWith("1.7."))
-      Seq("2.11.8")
-    else if (java.startsWith("1.8.") || java.startsWith("1.9."))
-      Seq("2.12.0", "2.12.1")
-    else
-      sys.error(s"don't know what Scala versions to build on $java")
+  repoName     := "scala-continuations",
+  organization := "org.scala-lang.plugins",
+  version      := "1.0.3-SNAPSHOT",
+
+  scalaVersionsByJvm := {
+    val j67 = List("2.11.11", "2.11.8")
+    val j89 = List("2.12.2", "2.12.1", "2.12.0", "2.13.0-M1")
+    // Map[JvmVersion, List[(ScalaVersion, UseForPublishing)]]
+    Map(
+      6 -> j67.map(_ -> true),
+      7 -> j67.map(_ -> false),
+      8 -> j89.map(_ -> true),
+      9 -> j89.map(_ -> false)
+    )
   },
-  snapshotScalaBinaryVersion := "2.11.8",
+
   scalacOptions ++= Seq(
     "-deprecation",
     "-feature")
@@ -36,43 +36,47 @@ lazy val crossVersionSharedSources: Seq[Setting[_]] =
     }
   }
 
-lazy val root = project.in( file(".") ).settings( publishArtifact := false ).aggregate(plugin, library).settings(commonSettings : _*)
+lazy val root = project.in(file("."))
+  .settings(commonSettings: _*)
+  .settings(publishArtifact := false)
+  .aggregate(plugin, library)
 
-lazy val plugin = project settings (scalaModuleOsgiSettings: _*) settings (
-  name                   := "scala-continuations-plugin",
-  crossVersion           := CrossVersion.full, // because compiler api is not binary compatible
-  libraryDependencies    += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  OsgiKeys.exportPackage := Seq(s"scala.tools.selectivecps;version=${version.value}")
-) settings (commonSettings : _*)
+lazy val plugin = project
+  .settings(commonSettings: _*)
+  .settings(
+    name                   := "scala-continuations-plugin",
+    crossVersion           := CrossVersion.full, // because compiler api is not binary compatible
+    libraryDependencies    += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    OsgiKeys.exportPackage := Seq(s"scala.tools.selectivecps;version=${version.value}")
+  )
 
 val pluginJar = packageTask in (plugin, Compile)
 
 // TODO: the library project's test are really plugin tests, but we first need that jar
-lazy val library = project settings (scalaModuleOsgiSettings: _*) settings (MimaPlugin.mimaDefaultSettings: _*) settings (
-  name                       := "scala-continuations-library",
-  MimaKeys.mimaPreviousArtifacts  := Set(
-    organization.value % s"${name.value}_2.11" % "1.0.2"
-  ),
-  scalacOptions       ++= Seq(
-    // add the plugin to the compiler
-    s"-Xplugin:${pluginJar.value.getAbsolutePath}",
-    // enable the plugin
-    "-P:continuations:enable",
-    // add plugin timestamp to compiler options to trigger recompile of
-    // the library after editing the plugin. (Otherwise a 'clean' is needed.)
-    s"-Jdummy=${pluginJar.value.lastModified}"),
-  libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-compiler"  % scalaVersion.value % "test",
-    "junit"          % "junit"           % "4.12" % "test",
-    "com.novocode"   % "junit-interface" % "0.11" % "test"),
-  testOptions          += Tests.Argument(
-    TestFrameworks.JUnit,
-    s"-Dscala-continuations-plugin.jar=${pluginJar.value.getAbsolutePath}"
-  ),
-  // run mima during tests
-  test in Test := {
-    MimaKeys.mimaReportBinaryIssues.value
-    (test in Test).value
-  },
-  OsgiKeys.exportPackage := Seq(s"scala.util.continuations;version=${version.value}")
-) settings (commonSettings : _*)
+lazy val library = project
+  .settings(commonSettings: _*)
+  .settings(
+    name                := "scala-continuations-library",
+    mimaPreviousVersion := Some("1.0.3"),
+
+    scalacOptions ++= Seq(
+      // add the plugin to the compiler
+      s"-Xplugin:${pluginJar.value.getAbsolutePath}",
+      // enable the plugin
+      "-P:continuations:enable",
+      // add plugin timestamp to compiler options to trigger recompile of
+      // the library after editing the plugin. (Otherwise a 'clean' is needed.)
+      s"-Jdummy=${pluginJar.value.lastModified}"),
+
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-compiler"  % scalaVersion.value % "test",
+      "junit"          % "junit"           % "4.12" % "test",
+      "com.novocode"   % "junit-interface" % "0.11" % "test"),
+
+    testOptions += Tests.Argument(
+      TestFrameworks.JUnit,
+      s"-Dscala-continuations-plugin.jar=${pluginJar.value.getAbsolutePath}"
+    ),
+
+    OsgiKeys.exportPackage := Seq(s"scala.util.continuations;version=${version.value}")
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.2")
-
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.9")
+addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.6")


### PR DESCRIPTION
- Update the sbt version
- Update scala-module-plugin
- Remove the explicit sbt-mima-plugin dependency, as it's provided
  via scala-module-plugin.
- Apply `commonSettings` before custom project settings to allow
  overrides
- Set `mimaPreviousVersion`, the rest of the mima config is done by the
  scala-module-plugin
- Define `scalaVersionsByJvm`
- Remove `snapshotScalaBinaryVersion`, there are no more Scala snapshots