### PR TITLE
allow building on JDK 9, 10, and 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,9 @@ scalaVersionsByJvm in ThisBuild := {
     6 -> j67.map(_ -> true),
     7 -> j67.map(_ -> false),
     8 -> j89.map(_ -> true),
-    9 -> j89.map(_ -> false)
+    9 -> j89.map(_ -> false),
+    10 -> j89.map(_ -> false),
+    11 -> j89.map(_ -> false)
   )
 }
 


### PR DESCRIPTION
context: I'm making a Scala community build on JDK 10.
might as well throw 11 in.